### PR TITLE
use :kbd: to mark key, simplify Copyright section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,14 +194,12 @@ Print version number.
 Controls
 ========
 
-Press any key to exit, except in Bash < 4, Control + C to exit.
+Press any key to exit, except in Bash < 4, :kbd:`Ctrl+C` to exit.
 
 
 Copyright
 =========
 
-pipesX.sh is licensed under `the MIT License`__::
+pipesX.sh is licensed under the MIT License, see LICENSE_.
 
-  Copyright (C) 2013, 2014 by Yu-Jie Lin
-
-__ LICENSE
+.. _LICENSE: LICENSE


### PR DESCRIPTION
It looks like github/markup#497 has not been deployed yet. Wait for the render showing the key style before merging.

---

This is kind of interesting, because I am updating a key for exiting. Perfectly fitting, only the action comes after the result.
